### PR TITLE
Remove concurrency settings from CI workflow to simplify job execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,6 @@ jobs:
   test:
     name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    # Prevent duplicate runs: cancel in-progress runs when new commits pushed
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
     strategy:
       fail-fast: false # Continue testing other platforms if one fails
       matrix:


### PR DESCRIPTION
This pull request makes a small change to the CI workflow configuration by removing the concurrency settings from the `test` job. This means that in-progress test runs will no longer be automatically cancelled when new commits are pushed.