### PR TITLE
refactor: Generalize documentation to remove Bicep-specific language

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: |
+          # NOTE: Bicep CLI installation is for testing the Bicep starter package
+          # The core Bolt orchestrator has no dependency on Bicep
           # Check if Bicep is already cached
           if command -v bicep &> /dev/null; then
             echo "✓ Using cached Bicep CLI"
@@ -90,6 +92,8 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
+          # NOTE: Bicep CLI installation is for testing the Bicep starter package
+          # The core Bolt orchestrator has no dependency on Bicep
           # Check if Bicep is already cached
           $bicepPath = "C:\Program Files\Bicep CLI\bicep.exe"
           if (Test-Path $bicepPath) {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,7 +18,7 @@
       "problemMatcher": []
     },
     {
-      "label": "Bolt: Format",
+      "label": "Bolt: Format Source",
       "type": "shell",
       "command": "pwsh",
       "args": ["-File", "${workspaceFolder}/bolt.ps1", "format"],
@@ -30,7 +30,7 @@
       "problemMatcher": []
     },
     {
-      "label": "Bolt: Lint",
+      "label": "Bolt: Lint Source",
       "type": "shell",
       "command": "pwsh",
       "args": ["-File", "${workspaceFolder}/bolt.ps1", "lint"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Works in both script mode (`.\bolt.ps1 -ListVariables`) and module mode (`bolt -ListVariables`)
   - JSON schema validation on add/remove operations
   - Human-readable output with syntax-highlighted JSON display
-- **Bicep Task Refactoring**: Refactored all Bicep tasks to use `$BoltConfig` for data access
+- **Bicep Starter Package Refactoring**: Refactored all Bicep starter package tasks to use `$BoltConfig` for data access
   - Format, Lint, and Build tasks now use `$BoltConfig.ProjectRoot` instead of environment variables
   - Cleaner task implementation with safer nested value access patterns
   - Example demonstrates best practices for accessing configuration in tasks
@@ -125,7 +125,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Find-BuildDirectory` function for upward directory traversal
 - Cross-platform path detection using `$IsWindows`, `$IsLinux`, `$IsMacOS`
 - **Improved .gitignore**: Comprehensive reorganization with clear sections and comments
-  - Bicep Infrastructure: ARM templates, parameter files, configuration
+  - Bicep starter package infrastructure: ARM templates, parameter files, configuration
   - Test Results: Pester outputs, temporary directories
   - PowerShell Modules: Generated manifests, module installations
   - Development/IDE: Editor-specific files
@@ -233,12 +233,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `-NewTask` parameter to generate new task files with proper metadata
 - `-ListTasks` / `-Help` to display available tasks
 - Core tasks: `check-index` (git status validation)
-- Example Azure Bicep tasks: `format`, `lint`, `build`
+- Example Bicep starter package tasks: `format`, `lint`, `build`
 - Example Azure infrastructure (App Service + SQL Database)
 - Comprehensive test suite with Pester
   - Core orchestration tests (28 tests, fast)
   - Security validation tests (205 tests)
-  - Bicep task tests (16 tests)
+  - Bicep starter package tests (16 tests)
   - Test tags: `Core`, `Security`, `Bicep-Tasks`
 - VS Code integration:
   - Pre-configured tasks (build, format, lint, test)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A self-contained, cross-platform PowerShell build system with extensible task orchestration and automatic dependency resolution. Inspired by PSake, Make and Rake. Just PowerShell with no external dependencies - just PowerShell Core 7.0+.
 
-**Perfect for Azure Bicep infrastructure projects**, but flexible enough for any PowerShell workflow. Runs on Windows, Linux, and macOS.
+**Perfect for any build workflow** - infrastructure-as-code, application builds, testing pipelines, deployment automation, and more. Runs on Windows, Linux, and macOS.
 
 ## ✨ Features
 
@@ -39,8 +39,7 @@ A self-contained, cross-platform PowerShell build system with extensible task or
 
 1. Clone or download this repository
 2. Ensure PowerShell 7.0+ is installed
-3. Install Azure Bicep CLI: `winget install Microsoft.Bicep`
-4. Navigate to the project directory and run `.\bolt.ps1`
+3. Navigate to the project directory and run `.\bolt.ps1`
 
 **Option 2: Module Mode (Global Command)**
 
@@ -72,9 +71,9 @@ bolt build
 
 # Output:
 # Available tasks:
-#   build      - Compiles Bicep files to ARM JSON templates
-#   format     - Formats Bicep files using bicep format
-#   lint       - Validates Bicep files using bicep lint
+#   build      - Compiles source files
+#   format     - Formats source files
+#   lint       - Validates source files
 ```
 
 ### Run Your First Build
@@ -119,7 +118,7 @@ bolt build
 
 # Manage configuration variables
 .\bolt.ps1 -ListVariables
-.\bolt.ps1 -AddVariable -Name "IacPath" -Value "infrastructure/bicep"
+.\bolt.ps1 -AddVariable -Name "SourcePath" -Value "src"
 .\bolt.ps1 -RemoveVariable -VariableName "OldSetting"
 
 # Install as a module
@@ -151,6 +150,47 @@ cd ~/projects/bolt
 # Uninstall the module
 .\New-BoltModule.ps1 -Uninstall
 ```
+
+## 📦 Package Starters
+
+**Package starters** are pre-built task collections for specific toolchains and workflows. They provide ready-to-use task templates that you can install into your project's `.build/` directory.
+
+### Available Package Starters
+
+#### Bicep Starter Package (`packages/.build-bicep`)
+
+Infrastructure-as-Code tasks for Azure Bicep workflows.
+
+**Included Tasks:**
+- **`format`** - Formats Bicep files using `bicep format`
+- **`lint`** - Validates Bicep syntax using `bicep lint`
+- **`build`** - Compiles Bicep files to ARM JSON templates
+
+**Requirements:** Azure Bicep CLI - `winget install Microsoft.Bicep` (Windows) or https://aka.ms/bicep-install
+
+**Installation:**
+```powershell
+# Copy tasks from package starter to your project
+Copy-Item -Path "packages/.build-bicep/Invoke-*.ps1" -Destination ".build/" -Force
+```
+
+**Usage:**
+```powershell
+.\bolt.ps1 format  # Format Bicep files
+.\bolt.ps1 lint    # Validate syntax
+.\bolt.ps1 build   # Full pipeline: format → lint → build
+```
+
+### More Package Starters Coming Soon
+
+We're working on additional package starters for popular toolchains:
+- **TypeScript** - Build, lint, and test TypeScript projects
+- **Python** - Format (black/ruff), lint (pylint/flake8), test (pytest)
+- **Node.js** - Build, lint (ESLint), test (Jest/Mocha)
+- **Docker** - Build, tag, push container images
+- **Terraform** - Format, validate, plan infrastructure
+
+See [`packages/README.md`](packages/README.md) for details on available package starters and how to create your own.
 
 ## ⚙️ Parameter Sets
 
@@ -225,16 +265,17 @@ Bolt uses PowerShell parameter sets to provide a clean, validated interface with
 ```
 .
 ├── bolt.ps1                    # Main orchestrator
-├── .build/                     # User-customizable task templates
+├── .build/                     # User-customizable task templates (placeholders)
 │   ├── Invoke-Build.ps1        # Build task template
 │   ├── Invoke-Format.ps1       # Format task template
 │   └── Invoke-Lint.ps1         # Lint task template
-├── packages/                   # External task packages
-│   └── .build-bicep/           # Bicep task implementation (separate package)
+├── packages/                   # Package starters (pre-built task collections)
+│   ├── README.md               # Package starter documentation
+│   └── .build-bicep/           # Bicep starter package (IaC tasks)
 │       ├── Invoke-Build.ps1    # Compiles Bicep to ARM JSON
 │       ├── Invoke-Format.ps1   # Formats Bicep files
 │       ├── Invoke-Lint.ps1     # Validates Bicep syntax
-│       └── tests/              # Bicep-specific tests
+│       └── tests/              # Bicep starter package tests
 │           ├── Tasks.Tests.ps1 # Task validation tests
 │           ├── Integration.Tests.ps1 # End-to-end tests
 │           └── iac/            # Test infrastructure
@@ -253,16 +294,24 @@ Bolt uses PowerShell parameter sets to provide a clean, validated interface with
     └── copilot-instructions.md # AI agent guidance
 ```
 
+### Package Starters vs. Project Tasks
+
+- **`.build/`** - Your project-specific tasks (starts with placeholder templates)
+- **`packages/`** - Pre-built task collections for specific toolchains
+  - Install by copying starter package tasks to `.build/`
+  - Each starter is self-contained with tests and documentation
+  - See [`packages/README.md`](packages/README.md) for details
+
 ### Example Infrastructure
 
-The project includes a complete Azure infrastructure example:
+The Bicep starter package (`packages/.build-bicep`) includes a complete Azure infrastructure example for testing:
 
 - **App Service Plan**: Hosting environment with configurable SKU
 - **Web App**: Azure App Service with managed identity
 - **SQL Server**: Azure SQL Server with firewall rules
 - **SQL Database**: Database with configurable DTU/storage
 
-All modules are parameterized and support multiple environments (dev, staging, prod).
+All modules are parameterized and support multiple environments (dev, staging, prod). These are example templates used for testing the Bicep starter package tasks.
 
 ## 🛠️ Creating Tasks
 
@@ -443,10 +492,10 @@ Tasks in a dependency chain do **NOT** pass pipeline objects to each other:
 
 ```powershell
 # Create a configuration file (manually or via -AddVariable)
-echo '{ "IacPath": "tests/iac", "Environment": "dev" }' > bolt.config.json
+echo '{ "SourcePath": "src", "Environment": "dev" }' > bolt.config.json
 
 # Or use the CLI
-.\bolt.ps1 -AddVariable -Name "IacPath" -Value "tests/iac"
+.\bolt.ps1 -AddVariable -Name "SourcePath" -Value "src"
 .\bolt.ps1 -AddVariable -Name "Environment" -Value "dev"
 
 # View all variables
@@ -461,10 +510,10 @@ echo '{ "IacPath": "tests/iac", "Environment": "dev" }' > bolt.config.json
 # DESCRIPTION: Deploy infrastructure
 
 # Access configuration values
-$iacPath = $BoltConfig.IacPath
+$sourcePath = $BoltConfig.SourcePath
 $environment = $BoltConfig.Environment
 
-Write-Host "Deploying from: $iacPath" -ForegroundColor Cyan
+Write-Host "Deploying from: $sourcePath" -ForegroundColor Cyan
 Write-Host "Environment: $environment" -ForegroundColor Gray
 
 exit 0
@@ -509,7 +558,7 @@ exit 0
 
 ```json
 {
-  "IacPath": "infrastructure/bicep",
+  "SourcePath": "src",
   "Environment": "dev",
   "Azure": {
     "SubscriptionId": "00000000-0000-0000-0000-000000000000",
@@ -555,9 +604,9 @@ The `-Outline` flag displays the task dependency tree and execution order **with
 # Output:
 # Task execution plan for: build
 #
-# build (Compiles Bicep files to ARM JSON templates)
-# ├── format (Formats Bicep files using bicep format)
-# └── lint (Validates Bicep syntax and runs linter)
+# build (Compiles source files)
+# ├── format (Formats source files)
+# └── lint (Validates source files)
 #
 # Execution order:
 #   1. format
@@ -1172,14 +1221,17 @@ exit
 # Then reopen and try again
 ```
 
-### Bicep CLI not found
+### External tool not found
 
 ```powershell
-# Install Bicep
+# Install the required tool for your tasks
+# Example for Bicep (if using Bicep starter package):
 winget install Microsoft.Bicep
 
 # Verify installation
 bicep --version
+
+# For other tools, see package starter documentation
 ```
 
 ### Task fails silently
@@ -1208,8 +1260,8 @@ Contributions welcome! This is a self-contained build system - keep it simple an
 
 1. **Keep `bolt.ps1`**: The orchestrator rarely needs modification
 2. **Modify tasks in `.build/`**: Edit existing tasks or add new ones
-3. **Update infrastructure in `tests/iac/`**: Replace with your own Bicep modules
-4. **Adjust parameters**: Edit `*.parameters.json` files for your environment
+3. **Install package starters**: Use pre-built task collections for your toolchain (see `packages/README.md`)
+4. **Update configuration**: Edit `bolt.config.json` for project-specific settings
 
 ### Adding a New Task
 
@@ -1256,8 +1308,8 @@ Bolt includes a GitHub Actions workflow that runs on Ubuntu and Windows:
   - Push builds run on all branches (including topic branches)
   - Duplicate builds prevented when PR is open (only PR build runs)
 - **Platforms**: Ubuntu (Linux) and Windows
-- **Pipeline**: Core tests → Tasks tests → Full build (format → lint → build)
-- **Dependencies**: Automatically installs PowerShell 7.0+ and Bicep CLI
+- **Pipeline**: Core tests → Starter package tests → Full build (format → lint → build)
+- **Dependencies**: Automatically installs PowerShell 7.0+ and tools required by starter packages (e.g., Bicep CLI for testing Bicep starter)
 - **Test Reports**: NUnit XML artifacts uploaded for each platform
 - **Status**: [![CI](https://github.com/motowilliams/bolt/actions/workflows/ci.yml/badge.svg)](https://github.com/motowilliams/bolt/actions/workflows/ci.yml)
 
@@ -1273,7 +1325,7 @@ Install-Module -Name Pester -MinimumVersion 5.0.0 -Force -Scope CurrentUser
 
 # Run tests (same as CI)
 Invoke-Pester -Tag Core    # Fast tests (~1s)
-Invoke-Pester -Tag Tasks   # Bicep tests (~22s)
+Invoke-Pester -Tag Bicep-Tasks   # Bicep starter package tests (~22s)
 Invoke-Pester             # All tests
 
 # Run build pipeline (same as CI)
@@ -1343,7 +1395,7 @@ It's the perfect name for a build orchestration tool that runs fast and efficien
 
 ### Design Goals
 
-- **Zero external dependencies**: Just PowerShell 7.0+ and your tools (Bicep, Git, etc.)
+- **Zero external dependencies**: Just PowerShell 7.0+ (tools like Bicep, Git, etc. are optional via package starters)
 - **Self-contained**: Single `bolt.ps1` file orchestrates everything
 - **Convention over configuration**: Drop tasks in `.build/`, they're discovered automatically
 - **Developer-friendly**: Tab completion, colorized output, helpful error messages

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1661,7 +1661,7 @@ Write-Host $sanitizedOutput
 **Action Items:**
 - [ ] Create `dependencies.json` manifest
 - [ ] Pin PowerShell version (currently >= 7.0)
-- [ ] Document Bicep CLI version requirements
+- [ ] Document external tool version requirements for package starters
 - [ ] Add Git version requirements
 - [ ] Include Pester version for testing
 - [ ] Implement version checking at script startup
@@ -1677,7 +1677,7 @@ Write-Host $sanitizedOutput
     "git": ">=2.30.0"
   },
   "optionalDependencies": {
-    "bicep": ">=0.20.0",
+    "bicep": ">=0.20.0",  // Example for Bicep starter package
     "azure-cli": ">=2.50.0"
   }
 }
@@ -1709,14 +1709,14 @@ function Test-Dependencies {
 ```
 Task: Implement dependency pinning and version checking in Bolt
 
-Context: The project needs to track and verify versions of external dependencies (PowerShell, Git, Pester, Bicep) for supply chain security and reproducible builds.
+Context: The project needs to track and verify versions of external dependencies (PowerShell, Git, Pester, and tools required by package starters like Bicep CLI) for supply chain security and reproducible builds.
 
 Requirements:
 1. Create dependencies.json manifest file with:
    - PowerShell >= 7.2.0
    - Pester >= 5.0.0
    - Git >= 2.30.0
-   - Bicep >= 0.20.0 (optional)
+   - Bicep >= 0.20.0 (optional, for Bicep starter package)
    - Azure CLI >= 2.50.0 (optional)
 2. Implement Test-Dependencies function in bolt.ps1:
    - Load and parse dependencies.json
@@ -2186,7 +2186,7 @@ The following items have been evaluated and marked as **Won't Implement** based 
 #### [x] L3 (Won't Implement): Implement License Compliance Scanning
 **Category:** Legal Compliance
 
-> **Note:** This feature will not be added to Bolt. License compliance scanning is not applicable to this build orchestrator project. Dependencies are managed at the system level (PowerShell modules, Bicep CLI, Git) and are the responsibility of the development environment, not the build script.
+> **Note:** This feature will not be added to Bolt. License compliance scanning is not applicable to this build orchestrator project. Dependencies are managed at the system level (PowerShell modules, external tools like Bicep CLI, Git) and are the responsibility of the development environment, not the build script.
 
 ---
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,107 @@
+# Bolt Package Starters
+
+This directory contains **package starters** - pre-built task collections for specific toolchains and workflows. Package starters provide ready-to-use task templates that you can install into your project's `.build/` directory.
+
+## Available Package Starters
+
+### `.build-bicep` - Bicep Starter Package
+
+Infrastructure-as-Code tasks for Azure Bicep workflows.
+
+**Included Tasks:**
+- **`format`** - Formats Bicep files using `bicep format`
+- **`lint`** - Validates Bicep syntax using `bicep lint`
+- **`build`** - Compiles Bicep files to ARM JSON templates
+
+**Requirements:**
+- Azure Bicep CLI: `winget install Microsoft.Bicep` (Windows) or https://aka.ms/bicep-install
+
+**Installation:**
+Copy the task files from `packages/.build-bicep/` to your project's `.build/` directory:
+
+```powershell
+# From your project root
+Copy-Item -Path "packages/.build-bicep/Invoke-*.ps1" -Destination ".build/" -Force
+```
+
+**Usage:**
+```powershell
+# Format all Bicep files
+.\bolt.ps1 format
+
+# Validate Bicep syntax
+.\bolt.ps1 lint
+
+# Full build pipeline (format → lint → build)
+.\bolt.ps1 build
+```
+
+**Testing:**
+The Bicep starter package includes comprehensive tests:
+- `packages/.build-bicep/tests/Tasks.Tests.ps1` - Task structure validation
+- `packages/.build-bicep/tests/Integration.Tests.ps1` - End-to-end integration tests
+- `packages/.build-bicep/tests/iac/` - Example infrastructure templates
+
+Run tests with: `Invoke-Pester -Tag Bicep-Tasks`
+
+## More Package Starters Coming Soon
+
+We're working on additional package starters for popular toolchains:
+
+- **TypeScript** - Build, lint, and test TypeScript projects
+- **Python** - Format (black/ruff), lint (pylint/flake8), test (pytest)
+- **Node.js** - Build, lint (ESLint), test (Jest/Mocha)
+- **Docker** - Build, tag, push container images
+- **Terraform** - Format, validate, plan infrastructure
+
+## Creating Your Own Package Starter
+
+Want to contribute a package starter? Here's the pattern:
+
+1. **Create a directory**: `packages/.build-<toolchain>/`
+2. **Add task files**: Follow the `Invoke-<TaskName>.ps1` naming convention
+3. **Include metadata**: Add comment-based metadata (`# TASK:`, `# DESCRIPTION:`, `# DEPENDS:`)
+4. **Add tests**: Include `tests/` directory with Pester tests
+5. **Document requirements**: Specify external tool dependencies
+6. **Add examples**: Include sample files for testing
+
+See `.build-bicep/` as a reference implementation.
+
+## Package Starter vs. Project Tasks
+
+- **Package Starters** (this directory): Reusable task collections for specific toolchains
+  - Installed by copying to your project
+  - Tested independently
+  - Tool-specific (requires external CLI tools)
+  
+- **Project Tasks** (`.build/` in project root): Your custom tasks
+  - Project-specific automation
+  - Can use package starter tasks as dependencies
+  - Can override package starter tasks
+
+## External Tool Dependency Pattern
+
+Package starters should check for required external tools before executing:
+
+```powershell
+# Example: Check for external CLI tool
+$toolCmd = Get-Command <tool-name> -ErrorAction SilentlyContinue
+if (-not $toolCmd) {
+    Write-Error "<Tool> CLI not found. Please install: <installation-instructions>"
+    exit 1
+}
+```
+
+See `packages/.build-bicep/Invoke-Build.ps1` for a real-world example of this pattern.
+
+## Contributing
+
+We welcome contributions! If you've created a package starter for a popular toolchain:
+
+1. Fork the repository
+2. Create a new package starter directory under `packages/`
+3. Add comprehensive tests
+4. Update this README with your package starter
+5. Submit a pull request
+
+For guidelines, see [CONTRIBUTING.md](../CONTRIBUTING.md)

--- a/tests/Performance.Tests.ps1
+++ b/tests/Performance.Tests.ps1
@@ -77,7 +77,8 @@ Describe "Bolt Performance Baseline" -Tag "Perf" {
 
     Context "Build Pipeline Performance" {
         BeforeAll {
-            # Check if Bicep CLI is available
+            # Check if external tool is available for starter package testing
+            # Example: Bicep CLI for Bicep starter package
             $script:BicepAvailable = $null -ne (Get-Command bicep -ErrorAction SilentlyContinue)
         }
 
@@ -96,7 +97,7 @@ Describe "Bolt Performance Baseline" -Tag "Perf" {
                 Write-Host "Full build pipeline took: $elapsedMs ms" -ForegroundColor Cyan
 
                 # Baseline threshold: full pipeline should complete reasonably fast
-                # Note: This includes Bicep CLI execution which may vary
+                # Note: This includes external tool execution (e.g., Bicep CLI) which may vary
                 $elapsedMs | Should -BeLessThan 5000
 
                 # Verify build succeeded


### PR DESCRIPTION
- Update project taglines from 'Perfect for Azure Bicep' to 'Perfect for any build workflow'
- Generalize all task examples (format/lint/build) to use generic 'source files' terminology
- Replace IacPath config examples with generic SourcePath throughout all docs
- Rename 'Bicep File Conventions' to 'Bicep Starter Package Conventions'
- Update 'Bicep-Specific Integration' to 'Example Package Integration Pattern'
- Clarify external tool dependency pattern with reference to Bicep starter
- Add comprehensive Package Starters section to README.md after Quick Start
- Create packages/README.md documenting starter package architecture
- Rename VS Code task labels to 'Format Source', 'Lint Source', 'Build'
- Update test descriptions to reference 'Bicep starter package tests'
- Add inline comments to CI workflow explaining Bicep is for testing starter
- Generalize troubleshooting sections across all documentation
- Update CHANGELOG.md and SECURITY.md to use 'Bicep starter package' terminology

All changes maintain accuracy while positioning Bolt as a generic build orchestrator.
The Bicep starter package (packages/.build-bicep) remains untouched as a valid example.