### PR TITLE
Adds Download script for fetching GitHub Releases

### DIFF
--- a/.github/prompts/create-release.prompt.md
+++ b/.github/prompts/create-release.prompt.md
@@ -1,0 +1,5 @@
+---
+agent: agent
+---
+
+Analyze the commits since the last tag and update the CHANGELOG.md document with the relevant information. Create a new release branch that once merged will be tagged with this next version. We are using SemVer so suggest a new version number based on the diff from the last tag. If it is not clear ask the operator what to use.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-12-24
+
+### Added
+- **Download Script**: New `Download.ps1` script for streamlined release installation
+  - Interactive menu displaying all GitHub releases sorted by version (oldest first, newest last)
+  - Shows release name, update date (ISO format), and prerelease indicators
+  - Automatic default selection for newest stable (non-prerelease) release
+  - Supports `-Latest` switch for non-interactive installation of latest stable release
+  - Downloads release zip and SHA256 checksum files to temporary directory
+  - Validates SHA256 checksum before extraction (fails if checksum file missing)
+  - Extracts to current directory creating `./Bolt/` subdirectory
+  - Automatic cleanup of temporary download files
+  - Designed for remote invocation via `Invoke-Expression` for easy installation:
+    ```powershell
+    iex (irm https://raw.githubusercontent.com/motowilliams/bolt/main/Download.ps1)
+    ```
+  - Includes coding standard exceptions for exit codes and CmdletBinding to support remote execution
+  
+### Changed
+- **Installation Documentation**: Updated README to include Download.ps1 usage instructions
+  - Added remote installation one-liner command
+  - Documented both interactive and auto-install modes
+  - Clarified next steps after download (navigate to Bolt/ and run installation)
+
 ## [0.1.1] - 2025-12-18
 
 ### Changed


### PR DESCRIPTION
This pull request introduces a new PowerShell download script for streamlined release installation and updates the release process documentation. The most significant changes include the addition of the `Download.ps1` script with interactive and automated installation features, updates to the installation instructions in the README, and a new prompt for automating release creation.

**Release Automation and Installation Improvements:**

* Added `Download.ps1` script for streamlined release installation, featuring an interactive menu of GitHub releases, automatic selection of the latest stable release, SHA256 checksum validation, extraction to a dedicated directory, and support for remote invocation via `Invoke-Expression`.
* Updated installation documentation in the README to include usage instructions for `Download.ps1`, including both interactive and automated installation methods, and clarified next steps after download.

**Release Process Automation:**

* Added `.github/prompts/create-release.prompt.md` with instructions for an agent to analyze commits, update the changelog, suggest a SemVer-compliant version, and create a release branch.