### PR TITLE
Fixes python package tests

### DIFF
--- a/packages/.build-python/bolt.config.json
+++ b/packages/.build-python/bolt.config.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../bolt.config.schema.json",
+  "PythonPath": "packages/.build-python/tests/app"
+}


### PR DESCRIPTION
Added `bolt.config.json` to the `packages/.build-python` directory, defining the schema and setting the `PythonPath` to `packages/.build-python/tests/app`.